### PR TITLE
feat: scaffold OnboardingCubit and state (#4)

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -5,7 +5,11 @@ class AppConstants {
   static const String routeProfile = '/profile';
   static const String routeProfileBadges = '/profile/badges';
 
+  // OAuth
+  static const String oauthRedirectUrl = 'io.hoosierciv://login-callback';
+
   // XP values (mirrors HoosierCiv_XP_Badge_System.txt)
+  static const int xpOnboardingComplete = 5;
   static const int xpCallLegislator = 20;
   static const int xpVoterRegistration = 10;
   static const int xpVoterStickerPhoto = 25;
@@ -21,6 +25,9 @@ class AppConstants {
   static const String hiveBoxMissions = 'missions';
   static const String hiveBoxBills = 'bills';
   static const String hiveBoxUser = 'user';
+
+  // Hive keys
+  static const String hiveKeyOnboardingComplete = 'onboarding_complete';
 
   // Cache TTLs
   static const Duration missionsCacheTtl = Duration(minutes: 15);

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -1,0 +1,31 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Thin abstraction over Supabase auth so the OnboardingCubit can be tested
+/// without a real SupabaseClient.
+abstract class AuthService {
+  Stream<AuthState> get onAuthStateChange;
+  User? get currentUser;
+  Future<void> signInWithOAuth(
+    OAuthProvider provider, {
+    String? redirectTo,
+  });
+}
+
+class SupabaseAuthService implements AuthService {
+  final SupabaseClient _supabase;
+
+  const SupabaseAuthService(this._supabase);
+
+  @override
+  Stream<AuthState> get onAuthStateChange => _supabase.auth.onAuthStateChange;
+
+  @override
+  User? get currentUser => _supabase.auth.currentUser;
+
+  @override
+  Future<void> signInWithOAuth(
+    OAuthProvider provider, {
+    String? redirectTo,
+  }) =>
+      _supabase.auth.signInWithOAuth(provider, redirectTo: redirectTo);
+}

--- a/lib/data/models/official_response.dart
+++ b/lib/data/models/official_response.dart
@@ -1,0 +1,178 @@
+// Mirrors the TypeScript OfficialResponse returned by the lookup-district
+// Edge Function.
+
+class OfficialAddress {
+  final String address1;
+  final String address2;
+  final String city;
+  final String state;
+  final String postalCode;
+  final String phone1;
+  final String fax1;
+
+  const OfficialAddress({
+    required this.address1,
+    required this.address2,
+    required this.city,
+    required this.state,
+    required this.postalCode,
+    required this.phone1,
+    required this.fax1,
+  });
+
+  factory OfficialAddress.fromJson(Map<String, dynamic> json) {
+    return OfficialAddress(
+      address1: json['address_1'] as String? ?? '',
+      address2: json['address_2'] as String? ?? '',
+      city: json['city'] as String? ?? '',
+      state: json['state'] as String? ?? '',
+      postalCode: json['postal_code'] as String? ?? '',
+      phone1: json['phone_1'] as String? ?? '',
+      fax1: json['fax_1'] as String? ?? '',
+    );
+  }
+}
+
+class OfficialIdentifier {
+  final String identifierType;
+  final String identifierValue;
+
+  const OfficialIdentifier({
+    required this.identifierType,
+    required this.identifierValue,
+  });
+
+  factory OfficialIdentifier.fromJson(Map<String, dynamic> json) {
+    return OfficialIdentifier(
+      identifierType: json['identifier_type'] as String? ?? '',
+      identifierValue: json['identifier_value'] as String? ?? '',
+    );
+  }
+}
+
+class OfficialCommittee {
+  final String name;
+  final List<String> urls;
+  final String position;
+
+  const OfficialCommittee({
+    required this.name,
+    required this.urls,
+    required this.position,
+  });
+
+  factory OfficialCommittee.fromJson(Map<String, dynamic> json) {
+    return OfficialCommittee(
+      name: json['name'] as String? ?? '',
+      urls: List<String>.from(json['urls'] as List? ?? []),
+      position: json['position'] as String? ?? '',
+    );
+  }
+}
+
+class OfficialResponse {
+  final int ciceroId;
+  final String firstName;
+  final String lastName;
+  final String? middleInitial;
+  final String? salutation;
+  final String? nickname;
+  final String? preferredName;
+  final String? nameSuffix;
+
+  /// Computed from district_type: us_senate, us_house, national_exec,
+  /// senate, house, state_exec, local, local_exec.
+  final String chamber;
+  final String? officeTitle;
+  final String? party;
+  final String? districtType;
+  final String? districtOcdId;
+  final String? districtState;
+  final String? districtCity;
+  final String? districtLabel;
+  final String? chamberName;
+  final String? chamberNameFormal;
+  final String? photoUrl;
+  final String? websiteUrl;
+  final String? webFormUrl;
+  final List<OfficialAddress> addresses;
+  final List<String> emailAddresses;
+  final List<OfficialIdentifier> identifiers;
+  final List<OfficialCommittee> committees;
+  final String? termStartDate;
+  final String? termEndDate;
+  final String? bio;
+  final String? birthDate;
+
+  const OfficialResponse({
+    required this.ciceroId,
+    required this.firstName,
+    required this.lastName,
+    this.middleInitial,
+    this.salutation,
+    this.nickname,
+    this.preferredName,
+    this.nameSuffix,
+    required this.chamber,
+    this.officeTitle,
+    this.party,
+    this.districtType,
+    this.districtOcdId,
+    this.districtState,
+    this.districtCity,
+    this.districtLabel,
+    this.chamberName,
+    this.chamberNameFormal,
+    this.photoUrl,
+    this.websiteUrl,
+    this.webFormUrl,
+    required this.addresses,
+    required this.emailAddresses,
+    required this.identifiers,
+    required this.committees,
+    this.termStartDate,
+    this.termEndDate,
+    this.bio,
+    this.birthDate,
+  });
+
+  factory OfficialResponse.fromJson(Map<String, dynamic> json) {
+    return OfficialResponse(
+      ciceroId: json['cicero_id'] as int,
+      firstName: json['first_name'] as String? ?? '',
+      lastName: json['last_name'] as String? ?? '',
+      middleInitial: json['middle_initial'] as String?,
+      salutation: json['salutation'] as String?,
+      nickname: json['nickname'] as String?,
+      preferredName: json['preferred_name'] as String?,
+      nameSuffix: json['name_suffix'] as String?,
+      chamber: json['chamber'] as String? ?? '',
+      officeTitle: json['office_title'] as String?,
+      party: json['party'] as String?,
+      districtType: json['district_type'] as String?,
+      districtOcdId: json['district_ocd_id'] as String?,
+      districtState: json['district_state'] as String?,
+      districtCity: json['district_city'] as String?,
+      districtLabel: json['district_label'] as String?,
+      chamberName: json['chamber_name'] as String?,
+      chamberNameFormal: json['chamber_name_formal'] as String?,
+      photoUrl: json['photo_url'] as String?,
+      websiteUrl: json['website_url'] as String?,
+      webFormUrl: json['web_form_url'] as String?,
+      addresses: (json['addresses'] as List? ?? [])
+          .map((a) => OfficialAddress.fromJson(a as Map<String, dynamic>))
+          .toList(),
+      emailAddresses: List<String>.from(json['email_addresses'] as List? ?? []),
+      identifiers: (json['identifiers'] as List? ?? [])
+          .map((i) => OfficialIdentifier.fromJson(i as Map<String, dynamic>))
+          .toList(),
+      committees: (json['committees'] as List? ?? [])
+          .map((c) => OfficialCommittee.fromJson(c as Map<String, dynamic>))
+          .toList(),
+      termStartDate: json['term_start_date'] as String?,
+      termEndDate: json['term_end_date'] as String?,
+      bio: json['bio'] as String?,
+      birthDate: json['birth_date'] as String?,
+    );
+  }
+}

--- a/lib/data/models/profile_model.dart
+++ b/lib/data/models/profile_model.dart
@@ -91,7 +91,8 @@ class ProfileModel {
       lastMissionAt: identical(lastMissionAt, _sentinel)
           ? this.lastMissionAt
           : lastMissionAt as DateTime?,
-      zipCode: identical(zipCode, _sentinel) ? this.zipCode : zipCode as String?,
+      zipCode:
+          identical(zipCode, _sentinel) ? this.zipCode : zipCode as String?,
       districtId: identical(districtId, _sentinel)
           ? this.districtId
           : districtId as String?,

--- a/lib/data/repositories/district_repository.dart
+++ b/lib/data/repositories/district_repository.dart
@@ -1,0 +1,41 @@
+import 'package:hoosierciv/data/models/official_response.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class DistrictLookupResult {
+  final String districtId;
+  final List<OfficialResponse> officials;
+
+  const DistrictLookupResult({
+    required this.districtId,
+    required this.officials,
+  });
+}
+
+class DistrictRepository {
+  final SupabaseClient _supabase;
+
+  const DistrictRepository({required SupabaseClient supabase})
+      : _supabase = supabase;
+
+  Future<DistrictLookupResult> lookupDistrict(String zipCode) async {
+    final response = await _supabase.functions.invoke(
+      'lookup-district',
+      body: {'zip_code': zipCode},
+    );
+
+    if (response.status != 200) {
+      final message =
+          (response.data as Map<String, dynamic>?)?['error'] as String? ??
+              'Failed to look up district';
+      throw Exception(message);
+    }
+
+    final data = response.data as Map<String, dynamic>;
+    final districtId = data['district_id'] as String;
+    final officials = (data['officials'] as List? ?? [])
+        .map((o) => OfficialResponse.fromJson(o as Map<String, dynamic>))
+        .toList();
+
+    return DistrictLookupResult(districtId: districtId, officials: officials);
+  }
+}

--- a/lib/data/repositories/profile_repository.dart
+++ b/lib/data/repositories/profile_repository.dart
@@ -27,7 +27,17 @@ class ProfileRepository {
       throw StateError('Cannot update profile without an authenticated user.');
     }
 
-    final payload = profile.toJson()..['id'] = userId;
+    // Send only mutable, non-gamification fields so that an upsert never
+    // clobbers immutable columns (created_at) or fields managed by other
+    // flows (xp_total, level, streak_count, last_mission_at).
+    final payload = <String, dynamic>{
+      'id': userId,
+      'display_name': profile.displayName,
+      'zip_code': profile.zipCode,
+      'district_id': profile.districtId,
+      'interests': profile.interests,
+      'onboarding_completed': profile.onboardingCompleted,
+    };
 
     final data = await _supabase
         .from('profiles')

--- a/lib/data/repositories/profile_repository.dart
+++ b/lib/data/repositories/profile_repository.dart
@@ -29,8 +29,7 @@ class ProfileRepository {
 
     final data = await _supabase
         .from('profiles')
-        .update(profile.toJson())
-        .eq('id', userId)
+        .upsert(profile.toJson())
         .select()
         .single();
 

--- a/lib/data/repositories/profile_repository.dart
+++ b/lib/data/repositories/profile_repository.dart
@@ -27,9 +27,11 @@ class ProfileRepository {
       throw StateError('Cannot update profile without an authenticated user.');
     }
 
+    final payload = profile.toJson()..['id'] = userId;
+
     final data = await _supabase
         .from('profiles')
-        .upsert(profile.toJson())
+        .upsert(payload)
         .select()
         .single();
 

--- a/lib/features/onboarding/onboarding_cubit.dart
+++ b/lib/features/onboarding/onboarding_cubit.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:hoosierciv/core/constants/app_constants.dart';
+import 'package:hoosierciv/core/services/auth_service.dart';
+import 'package:hoosierciv/data/models/profile_model.dart';
+import 'package:hoosierciv/data/repositories/district_repository.dart';
+import 'package:hoosierciv/data/repositories/profile_repository.dart';
+import 'package:hoosierciv/features/onboarding/onboarding_state.dart';
+import 'package:hoosierciv/state/gamification_cubit.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class OnboardingCubit extends Cubit<OnboardingState> {
+  final DistrictRepository _districtRepository;
+  final ProfileRepository _profileRepository;
+  final GamificationCubit _gamificationCubit;
+  final AuthService _authService;
+
+  late final StreamSubscription<AuthState> _authSubscription;
+
+  OnboardingCubit({
+    required DistrictRepository districtRepository,
+    required ProfileRepository profileRepository,
+    required GamificationCubit gamificationCubit,
+    required AuthService authService,
+  })  : _districtRepository = districtRepository,
+        _profileRepository = profileRepository,
+        _gamificationCubit = gamificationCubit,
+        _authService = authService,
+        super(const OnboardingInitial()) {
+    _authSubscription =
+        _authService.onAuthStateChange.listen(_onAuthStateChange);
+  }
+
+  void _onAuthStateChange(AuthState authState) {
+    if (authState.event == AuthChangeEvent.signedIn &&
+        state is OnboardingAuthPending) {
+      completeOnboarding();
+    }
+  }
+
+  /// Validates the ZIP locally then calls the lookup-district Edge Function.
+  ///
+  /// Rejects any ZIP not starting with 46 or 47 before making an API call.
+  Future<void> submitZip(String zip) async {
+    final trimmed = zip.trim();
+
+    if (!_isIndianaZip(trimmed)) {
+      emit(const OnboardingError(
+        'Please enter a valid Indiana ZIP code (starts with 46 or 47).',
+      ));
+      return;
+    }
+
+    emit(const OnboardingZipLoading());
+
+    try {
+      final result = await _districtRepository.lookupDistrict(trimmed);
+      emit(OnboardingZipVerified(
+        zipCode: trimmed,
+        districtId: result.districtId,
+        officials: result.officials,
+      ));
+    } on Exception catch (e) {
+      emit(OnboardingError(_stripExceptionPrefix(e)));
+    }
+  }
+
+  /// Triggers Google or Apple Sign-In via Supabase OAuth.
+  ///
+  /// Emits [OnboardingAuthPending] immediately. [_onAuthStateChange] handles
+  /// completion once the OAuth deep-link returns to the app.
+  Future<void> submitAuth(OAuthProvider provider) async {
+    final current = state;
+    if (current is! OnboardingZipVerified) return;
+
+    emit(OnboardingAuthPending(
+      zipCode: current.zipCode,
+      districtId: current.districtId,
+      officials: current.officials,
+    ));
+
+    try {
+      await _authService.signInWithOAuth(
+        provider,
+        redirectTo: AppConstants.oauthRedirectUrl,
+      );
+    } on Exception catch (e) {
+      emit(OnboardingError(_stripExceptionPrefix(e)));
+    }
+  }
+
+  /// Saves the profile, sets the Hive onboarding flag, and awards XP.
+  ///
+  /// Called automatically by [_onAuthStateChange] when OAuth completes.
+  Future<void> completeOnboarding() async {
+    final current = state;
+    if (current is! OnboardingAuthPending) return;
+
+    try {
+      final user = _authService.currentUser;
+      if (user == null) {
+        emit(const OnboardingError('Sign-in failed. Please try again.'));
+        return;
+      }
+
+      await _profileRepository.upsertProfile(
+        ProfileModel(
+          id: user.id,
+          xpTotal: 0,
+          level: 1,
+          streakCount: 0,
+          zipCode: current.zipCode,
+          districtId: current.districtId,
+          interests: const [],
+          onboardingCompleted: true,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        ),
+      );
+
+      final box = await Hive.openBox<dynamic>(AppConstants.hiveBoxUser);
+      await box.put(AppConstants.hiveKeyOnboardingComplete, true);
+
+      _gamificationCubit.awardXp(AppConstants.xpOnboardingComplete);
+
+      emit(const OnboardingComplete());
+    } on Exception catch (e) {
+      emit(OnboardingError(_stripExceptionPrefix(e)));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _authSubscription.cancel();
+    return super.close();
+  }
+
+  static bool _isIndianaZip(String zip) {
+    if (zip.length != 5) return false;
+    final prefix = int.tryParse(zip.substring(0, 2));
+    return prefix == 46 || prefix == 47;
+  }
+
+  static String _stripExceptionPrefix(Exception e) =>
+      e.toString().replaceFirst('Exception: ', '');
+}

--- a/lib/features/onboarding/onboarding_state.dart
+++ b/lib/features/onboarding/onboarding_state.dart
@@ -1,0 +1,47 @@
+import 'package:hoosierciv/data/models/official_response.dart';
+
+sealed class OnboardingState {
+  const OnboardingState();
+}
+
+final class OnboardingInitial extends OnboardingState {
+  const OnboardingInitial();
+}
+
+final class OnboardingZipLoading extends OnboardingState {
+  const OnboardingZipLoading();
+}
+
+final class OnboardingZipVerified extends OnboardingState {
+  final String zipCode;
+  final String districtId;
+  final List<OfficialResponse> officials;
+
+  const OnboardingZipVerified({
+    required this.zipCode,
+    required this.districtId,
+    required this.officials,
+  });
+}
+
+final class OnboardingAuthPending extends OnboardingState {
+  final String zipCode;
+  final String districtId;
+  final List<OfficialResponse> officials;
+
+  const OnboardingAuthPending({
+    required this.zipCode,
+    required this.districtId,
+    required this.officials,
+  });
+}
+
+final class OnboardingComplete extends OnboardingState {
+  const OnboardingComplete();
+}
+
+final class OnboardingError extends OnboardingState {
+  final String message;
+
+  const OnboardingError(this.message);
+}

--- a/lib/state/gamification_cubit.dart
+++ b/lib/state/gamification_cubit.dart
@@ -6,4 +6,8 @@ class GamificationState {
 
 class GamificationCubit extends Cubit<GamificationState> {
   GamificationCubit() : super(const GamificationState());
+
+  void awardXp(int xp) {
+    // TODO: implement XP accumulation
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -573,14 +573,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  hive_generator:
-    dependency: "direct dev"
-    description:
-      name: hive_generator
-      sha256: "06cb8f58ace74de61f63500564931f9505368f45f98958bd7a6c35ba24159db4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   http:
     dependency: transitive
     description:
@@ -1082,22 +1074,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
-  source_gen:
-    dependency: transitive
-    description:
-      name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.5.0"
-  source_helper:
-    dependency: transitive
-    description:
-      name: source_helper
-      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.5"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -94,6 +94,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
+  bloc_test:
+    dependency: "direct dev"
+    description:
+      name: bloc_test
+      sha256: "165a6ec950d9252ebe36dc5335f2e6eb13055f33d56db0eeb7642768849b43d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.7"
   boolean_selector:
     dependency: transitive
     description:
@@ -206,6 +214,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -238,6 +254,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -270,6 +294,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
+  diff_match_patch:
+    dependency: transitive
+    description:
+      name: diff_match_patch
+      sha256: "2efc9e6e8f449d0abe15be240e2c2a3bcd977c8d126cfd70598aee60af35c0a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.1"
   ed25519_edwards:
     dependency: transitive
     description:
@@ -749,6 +781,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   nested:
     dependency: transitive
     description:
@@ -757,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   octo_image:
     dependency: transitive
     description:
@@ -1005,6 +1053,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -1034,6 +1098,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.5"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -1162,6 +1242,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.25.7"
   test_api:
     dependency: transitive
     description:
@@ -1170,6 +1258,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.4"
   tflite_flutter:
     dependency: "direct main"
     description:
@@ -1314,6 +1410,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  hive_generator: ^2.0.1
   build_runner: ^2.4.12
   flutter_lints: ^4.0.0
   bloc_test: ^9.1.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,8 @@ dev_dependencies:
   hive_generator: ^2.0.1
   build_runner: ^2.4.12
   flutter_lints: ^4.0.0
+  bloc_test: ^9.1.7
+  mocktail: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/supabase/functions/lookup-district/_handler.ts
+++ b/supabase/functions/lookup-district/_handler.ts
@@ -242,7 +242,7 @@ export async function handler(
 
     const officials = (joinRows ?? [])
       .map((r: { cicero_officials: unknown }) => fromCacheRow(r.cicero_officials))
-      .filter((o): o is OfficialResponse => o !== null);
+      .filter((o: OfficialResponse | null): o is OfficialResponse => o !== null);
 
     return new Response(
       JSON.stringify({ district_id: cached.district_id, officials }),

--- a/supabase/functions/lookup-district/cicero_service.ts
+++ b/supabase/functions/lookup-district/cicero_service.ts
@@ -46,7 +46,7 @@ export class CiceroService {
     }
 
     const data = await res.json() as CiceroResponse;
-    console.log(JSON.stringify(data, null, 2))
+
     const candidate: CiceroCandidate | undefined = data?.response?.results?.candidates?.[0];
 
     if (candidate?.match_region !== "IN") throw new CiceroError("ZIP code is not in Indiana", 422);

--- a/test/data/models/official_response_test.dart
+++ b/test/data/models/official_response_test.dart
@@ -1,0 +1,230 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hoosierciv/data/models/official_response.dart';
+
+void main() {
+  group('OfficialAddress.fromJson', () {
+    test('parses all fields', () {
+      final json = {
+        'address_1': '200 W Washington St',
+        'address_2': 'Suite 100',
+        'city': 'Indianapolis',
+        'state': 'IN',
+        'postal_code': '46204',
+        'phone_1': '317-555-0100',
+        'fax_1': '317-555-0101',
+      };
+      final addr = OfficialAddress.fromJson(json);
+      expect(addr.address1, '200 W Washington St');
+      expect(addr.address2, 'Suite 100');
+      expect(addr.city, 'Indianapolis');
+      expect(addr.state, 'IN');
+      expect(addr.postalCode, '46204');
+      expect(addr.phone1, '317-555-0100');
+      expect(addr.fax1, '317-555-0101');
+    });
+
+    test('defaults missing fields to empty string', () {
+      final addr = OfficialAddress.fromJson({});
+      expect(addr.address1, '');
+      expect(addr.address2, '');
+      expect(addr.city, '');
+      expect(addr.state, '');
+      expect(addr.postalCode, '');
+      expect(addr.phone1, '');
+      expect(addr.fax1, '');
+    });
+  });
+
+  group('OfficialIdentifier.fromJson', () {
+    test('parses all fields', () {
+      final json = {
+        'identifier_type': 'bioguide',
+        'identifier_value': 'A000001',
+      };
+      final id = OfficialIdentifier.fromJson(json);
+      expect(id.identifierType, 'bioguide');
+      expect(id.identifierValue, 'A000001');
+    });
+
+    test('defaults missing fields to empty string', () {
+      final id = OfficialIdentifier.fromJson({});
+      expect(id.identifierType, '');
+      expect(id.identifierValue, '');
+    });
+  });
+
+  group('OfficialCommittee.fromJson', () {
+    test('parses all fields', () {
+      final json = {
+        'name': 'Committee on Finance',
+        'urls': ['https://finance.senate.gov'],
+        'position': 'Chair',
+      };
+      final committee = OfficialCommittee.fromJson(json);
+      expect(committee.name, 'Committee on Finance');
+      expect(committee.urls, ['https://finance.senate.gov']);
+      expect(committee.position, 'Chair');
+    });
+
+    test('defaults missing fields to empty string and empty list', () {
+      final committee = OfficialCommittee.fromJson({});
+      expect(committee.name, '');
+      expect(committee.urls, isEmpty);
+      expect(committee.position, '');
+    });
+  });
+
+  group('OfficialResponse.fromJson', () {
+    final fullJson = {
+      'cicero_id': 12345,
+      'first_name': 'Jane',
+      'last_name': 'Smith',
+      'middle_initial': 'A',
+      'salutation': 'Sen.',
+      'nickname': 'JAS',
+      'preferred_name': 'Jane A.',
+      'name_suffix': 'Jr.',
+      'chamber': 'senate',
+      'office_title': 'Senator',
+      'party': 'D',
+      'district_type': 'STATE_UPPER',
+      'district_ocd_id': 'ocd-division/country:us/state:in/sldu:1',
+      'district_state': 'IN',
+      'district_city': null,
+      'district_label': 'Senate District 1',
+      'chamber_name': 'Indiana Senate',
+      'chamber_name_formal': 'The Indiana Senate',
+      'photo_url': 'https://example.com/photo.jpg',
+      'website_url': 'https://example.com',
+      'web_form_url': 'https://example.com/contact',
+      'addresses': [
+        {
+          'address_1': '200 W Washington St',
+          'address_2': '',
+          'city': 'Indianapolis',
+          'state': 'IN',
+          'postal_code': '46204',
+          'phone_1': '317-555-0100',
+          'fax_1': '',
+        }
+      ],
+      'email_addresses': ['jane@example.com'],
+      'identifiers': [
+        {'identifier_type': 'bioguide', 'identifier_value': 'A000001'}
+      ],
+      'committees': [
+        {
+          'name': 'Finance',
+          'urls': ['https://finance.senate.gov'],
+          'position': 'Member',
+        }
+      ],
+      'term_start_date': '2023-01-01',
+      'term_end_date': '2027-01-01',
+      'bio': 'A dedicated public servant.',
+      'birth_date': '1970-05-15',
+    };
+
+    test('parses all fields correctly', () {
+      final official = OfficialResponse.fromJson(fullJson);
+
+      expect(official.ciceroId, 12345);
+      expect(official.firstName, 'Jane');
+      expect(official.lastName, 'Smith');
+      expect(official.middleInitial, 'A');
+      expect(official.salutation, 'Sen.');
+      expect(official.nickname, 'JAS');
+      expect(official.preferredName, 'Jane A.');
+      expect(official.nameSuffix, 'Jr.');
+      expect(official.chamber, 'senate');
+      expect(official.officeTitle, 'Senator');
+      expect(official.party, 'D');
+      expect(official.districtType, 'STATE_UPPER');
+      expect(
+        official.districtOcdId,
+        'ocd-division/country:us/state:in/sldu:1',
+      );
+      expect(official.districtState, 'IN');
+      expect(official.districtCity, isNull);
+      expect(official.districtLabel, 'Senate District 1');
+      expect(official.chamberName, 'Indiana Senate');
+      expect(official.chamberNameFormal, 'The Indiana Senate');
+      expect(official.photoUrl, 'https://example.com/photo.jpg');
+      expect(official.websiteUrl, 'https://example.com');
+      expect(official.webFormUrl, 'https://example.com/contact');
+      expect(official.emailAddresses, ['jane@example.com']);
+      expect(official.termStartDate, '2023-01-01');
+      expect(official.termEndDate, '2027-01-01');
+      expect(official.bio, 'A dedicated public servant.');
+      expect(official.birthDate, '1970-05-15');
+    });
+
+    test('parses nested addresses', () {
+      final official = OfficialResponse.fromJson(fullJson);
+      expect(official.addresses.length, 1);
+      expect(official.addresses.first.city, 'Indianapolis');
+    });
+
+    test('parses nested identifiers', () {
+      final official = OfficialResponse.fromJson(fullJson);
+      expect(official.identifiers.length, 1);
+      expect(official.identifiers.first.identifierType, 'bioguide');
+    });
+
+    test('parses nested committees', () {
+      final official = OfficialResponse.fromJson(fullJson);
+      expect(official.committees.length, 1);
+      expect(official.committees.first.name, 'Finance');
+    });
+
+    test('handles null optional fields gracefully', () {
+      final minimalJson = {
+        'cicero_id': 99,
+        'first_name': 'John',
+        'last_name': 'Doe',
+        'chamber': 'house',
+      };
+      final official = OfficialResponse.fromJson(minimalJson);
+
+      expect(official.ciceroId, 99);
+      expect(official.firstName, 'John');
+      expect(official.lastName, 'Doe');
+      expect(official.chamber, 'house');
+      expect(official.middleInitial, isNull);
+      expect(official.salutation, isNull);
+      expect(official.nickname, isNull);
+      expect(official.preferredName, isNull);
+      expect(official.nameSuffix, isNull);
+      expect(official.officeTitle, isNull);
+      expect(official.party, isNull);
+      expect(official.districtType, isNull);
+      expect(official.districtOcdId, isNull);
+      expect(official.districtState, isNull);
+      expect(official.districtCity, isNull);
+      expect(official.districtLabel, isNull);
+      expect(official.chamberName, isNull);
+      expect(official.chamberNameFormal, isNull);
+      expect(official.photoUrl, isNull);
+      expect(official.websiteUrl, isNull);
+      expect(official.webFormUrl, isNull);
+      expect(official.addresses, isEmpty);
+      expect(official.emailAddresses, isEmpty);
+      expect(official.identifiers, isEmpty);
+      expect(official.committees, isEmpty);
+      expect(official.termStartDate, isNull);
+      expect(official.termEndDate, isNull);
+      expect(official.bio, isNull);
+      expect(official.birthDate, isNull);
+    });
+
+    test('defaults missing string fields to empty string', () {
+      final json = {
+        'cicero_id': 1,
+        'chamber': 'local',
+      };
+      final official = OfficialResponse.fromJson(json);
+      expect(official.firstName, '');
+      expect(official.lastName, '');
+    });
+  });
+}

--- a/test/features/onboarding/onboarding_cubit_test.dart
+++ b/test/features/onboarding/onboarding_cubit_test.dart
@@ -1,0 +1,397 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:hoosierciv/core/services/auth_service.dart';
+import 'package:hoosierciv/data/models/official_response.dart';
+import 'package:hoosierciv/data/models/profile_model.dart';
+import 'package:hoosierciv/data/repositories/district_repository.dart';
+import 'package:hoosierciv/data/repositories/profile_repository.dart';
+import 'package:hoosierciv/features/onboarding/onboarding_cubit.dart';
+import 'package:hoosierciv/features/onboarding/onboarding_state.dart';
+import 'package:hoosierciv/state/gamification_cubit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+// --- Mocks ---
+
+class MockDistrictRepository extends Mock implements DistrictRepository {}
+
+class MockProfileRepository extends Mock implements ProfileRepository {}
+
+class MockGamificationCubit extends Mock implements GamificationCubit {}
+
+class MockAuthService extends Mock implements AuthService {}
+
+class MockUser extends Mock implements User {
+  @override
+  String get id => 'test-user-id';
+}
+
+class _FakeProfileModel extends Fake implements ProfileModel {}
+
+// --- Fixtures ---
+
+const _emptyOfficial = OfficialResponse(
+  ciceroId: 1,
+  firstName: 'Jane',
+  lastName: 'Doe',
+  chamber: 'senate',
+  addresses: [],
+  emailAddresses: [],
+  identifiers: [],
+  committees: [],
+);
+
+const _lookupResult = DistrictLookupResult(
+  districtId: 'ocd-division/country:us/state:in/sldu:1',
+  officials: [_emptyOfficial],
+);
+
+// --- Helpers ---
+
+OnboardingCubit _makeCubit({
+  MockDistrictRepository? districtRepo,
+  MockProfileRepository? profileRepo,
+  MockGamificationCubit? gamification,
+  MockAuthService? auth,
+  StreamController<AuthState>? authController,
+}) {
+  final controller = authController ?? StreamController<AuthState>.broadcast();
+  final mockAuth = auth ?? MockAuthService();
+  when(() => mockAuth.onAuthStateChange).thenAnswer((_) => controller.stream);
+
+  return OnboardingCubit(
+    districtRepository: districtRepo ?? MockDistrictRepository(),
+    profileRepository: profileRepo ?? MockProfileRepository(),
+    gamificationCubit: gamification ?? MockGamificationCubit(),
+    authService: mockAuth,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(OAuthProvider.google);
+    registerFallbackValue(_FakeProfileModel());
+  });
+
+  group('submitZip', () {
+    blocTest<OnboardingCubit, OnboardingState>(
+      'emits OnboardingError for non-Indiana ZIP (starts with 45)',
+      build: () => _makeCubit(),
+      act: (cubit) => cubit.submitZip('45202'),
+      expect: () => [
+        isA<OnboardingError>().having(
+          (e) => e.message,
+          'message',
+          contains('Indiana'),
+        ),
+      ],
+    );
+
+    blocTest<OnboardingCubit, OnboardingState>(
+      'emits OnboardingError for ZIP shorter than 5 digits',
+      build: () => _makeCubit(),
+      act: (cubit) => cubit.submitZip('461'),
+      expect: () => [isA<OnboardingError>()],
+    );
+
+    blocTest<OnboardingCubit, OnboardingState>(
+      'emits [ZipLoading, ZipVerified] for valid Indiana ZIP starting with 46',
+      build: () {
+        final repo = MockDistrictRepository();
+        when(() => repo.lookupDistrict('46204'))
+            .thenAnswer((_) async => _lookupResult);
+        return _makeCubit(districtRepo: repo);
+      },
+      act: (cubit) => cubit.submitZip('46204'),
+      expect: () => [
+        isA<OnboardingZipLoading>(),
+        isA<OnboardingZipVerified>()
+            .having((s) => s.zipCode, 'zipCode', '46204')
+            .having(
+              (s) => s.districtId,
+              'districtId',
+              _lookupResult.districtId,
+            )
+            .having((s) => s.officials, 'officials', _lookupResult.officials),
+      ],
+    );
+
+    blocTest<OnboardingCubit, OnboardingState>(
+      'emits [ZipLoading, ZipVerified] for valid Indiana ZIP starting with 47',
+      build: () {
+        final repo = MockDistrictRepository();
+        when(() => repo.lookupDistrict('47401'))
+            .thenAnswer((_) async => _lookupResult);
+        return _makeCubit(districtRepo: repo);
+      },
+      act: (cubit) => cubit.submitZip('47401'),
+      expect: () => [isA<OnboardingZipLoading>(), isA<OnboardingZipVerified>()],
+    );
+
+    blocTest<OnboardingCubit, OnboardingState>(
+      'trims whitespace before validating',
+      build: () {
+        final repo = MockDistrictRepository();
+        when(() => repo.lookupDistrict('46204'))
+            .thenAnswer((_) async => _lookupResult);
+        return _makeCubit(districtRepo: repo);
+      },
+      act: (cubit) => cubit.submitZip('  46204  '),
+      expect: () => [isA<OnboardingZipLoading>(), isA<OnboardingZipVerified>()],
+    );
+
+    blocTest<OnboardingCubit, OnboardingState>(
+      'emits OnboardingError when lookupDistrict throws',
+      build: () {
+        final repo = MockDistrictRepository();
+        when(() => repo.lookupDistrict(any())).thenThrow(
+          Exception('District not found'),
+        );
+        return _makeCubit(districtRepo: repo);
+      },
+      act: (cubit) => cubit.submitZip('46204'),
+      expect: () => [
+        isA<OnboardingZipLoading>(),
+        isA<OnboardingError>().having(
+          (e) => e.message,
+          'message',
+          'District not found',
+        ),
+      ],
+    );
+  });
+
+  group('submitAuth', () {
+    blocTest<OnboardingCubit, OnboardingState>(
+      'does nothing when state is not OnboardingZipVerified',
+      build: () => _makeCubit(),
+      act: (cubit) => cubit.submitAuth(OAuthProvider.google),
+      expect: () => [],
+    );
+
+    blocTest<OnboardingCubit, OnboardingState>(
+      'emits OnboardingAuthPending and calls signInWithOAuth',
+      build: () {
+        final repo = MockDistrictRepository();
+        when(() => repo.lookupDistrict('46204'))
+            .thenAnswer((_) async => _lookupResult);
+
+        final auth = MockAuthService();
+        final controller = StreamController<AuthState>.broadcast();
+        when(() => auth.onAuthStateChange).thenAnswer((_) => controller.stream);
+        when(
+          () =>
+              auth.signInWithOAuth(any(), redirectTo: any(named: 'redirectTo')),
+        ).thenAnswer((_) async {});
+
+        return OnboardingCubit(
+          districtRepository: repo,
+          profileRepository: MockProfileRepository(),
+          gamificationCubit: MockGamificationCubit(),
+          authService: auth,
+        );
+      },
+      act: (cubit) async {
+        await cubit.submitZip('46204');
+        await cubit.submitAuth(OAuthProvider.google);
+      },
+      expect: () => [
+        isA<OnboardingZipLoading>(),
+        isA<OnboardingZipVerified>(),
+        isA<OnboardingAuthPending>()
+            .having((s) => s.zipCode, 'zipCode', '46204')
+            .having((s) => s.districtId, 'districtId', _lookupResult.districtId)
+            .having(
+              (s) => s.officials,
+              'officials',
+              _lookupResult.officials,
+            ),
+      ],
+    );
+
+    blocTest<OnboardingCubit, OnboardingState>(
+      'emits OnboardingError when signInWithOAuth throws',
+      build: () {
+        final repo = MockDistrictRepository();
+        when(() => repo.lookupDistrict('46204'))
+            .thenAnswer((_) async => _lookupResult);
+
+        final auth = MockAuthService();
+        final controller = StreamController<AuthState>.broadcast();
+        when(() => auth.onAuthStateChange).thenAnswer((_) => controller.stream);
+        when(
+          () =>
+              auth.signInWithOAuth(any(), redirectTo: any(named: 'redirectTo')),
+        ).thenThrow(Exception('OAuth failed'));
+
+        return OnboardingCubit(
+          districtRepository: repo,
+          profileRepository: MockProfileRepository(),
+          gamificationCubit: MockGamificationCubit(),
+          authService: auth,
+        );
+      },
+      act: (cubit) async {
+        await cubit.submitZip('46204');
+        await cubit.submitAuth(OAuthProvider.google);
+      },
+      expect: () => [
+        isA<OnboardingZipLoading>(),
+        isA<OnboardingZipVerified>(),
+        isA<OnboardingAuthPending>(),
+        isA<OnboardingError>()
+            .having((e) => e.message, 'message', 'OAuth failed'),
+      ],
+    );
+  });
+
+  group('completeOnboarding (via auth state change)', () {
+    late Directory hiveDir;
+
+    setUp(() async {
+      hiveDir = await Directory.systemTemp.createTemp('hive_test_');
+      Hive.init(hiveDir.path);
+    });
+
+    tearDown(() async {
+      await Hive.close();
+      await hiveDir.delete(recursive: true);
+    });
+
+    blocTest<OnboardingCubit, OnboardingState>(
+      'does nothing when state is not OnboardingAuthPending',
+      build: () => _makeCubit(),
+      act: (cubit) => cubit.completeOnboarding(),
+      expect: () => [],
+    );
+
+    test('emits OnboardingComplete after signedIn event fires', () async {
+      final authController = StreamController<AuthState>.broadcast();
+      final auth = MockAuthService();
+      when(() => auth.onAuthStateChange)
+          .thenAnswer((_) => authController.stream);
+      when(
+        () => auth.signInWithOAuth(any(), redirectTo: any(named: 'redirectTo')),
+      ).thenAnswer((_) async {});
+
+      final mockUser = MockUser();
+      when(() => auth.currentUser).thenReturn(mockUser);
+
+      final profileRepo = MockProfileRepository();
+      when(() => profileRepo.upsertProfile(any())).thenAnswer(
+        (_) async => ProfileModel(
+          id: 'test-user-id',
+          xpTotal: 0,
+          level: 1,
+          streakCount: 0,
+          interests: const [],
+          onboardingCompleted: true,
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+        ),
+      );
+
+      final gamification = MockGamificationCubit();
+      when(() => gamification.awardXp(any())).thenReturn(null);
+
+      final districtRepo = MockDistrictRepository();
+      when(() => districtRepo.lookupDistrict('46204'))
+          .thenAnswer((_) async => _lookupResult);
+
+      final cubit = OnboardingCubit(
+        districtRepository: districtRepo,
+        profileRepository: profileRepo,
+        gamificationCubit: gamification,
+        authService: auth,
+      );
+
+      final states = <OnboardingState>[];
+      final sub = cubit.stream.listen(states.add);
+
+      await cubit.submitZip('46204');
+      await cubit.submitAuth(OAuthProvider.google);
+
+      // Simulate the OAuth deep-link returning — fire the event and then
+      // wait for the cubit to reach OnboardingComplete before asserting.
+      final fakeSession = _FakeSession();
+
+      final doneFuture = cubit.stream
+          .firstWhere((s) => s is OnboardingComplete)
+          .timeout(const Duration(seconds: 5));
+
+      authController.add(AuthState(AuthChangeEvent.signedIn, fakeSession));
+
+      await doneFuture;
+
+      await sub.cancel();
+      await cubit.close();
+      await authController.close();
+
+      expect(states.last, isA<OnboardingComplete>());
+      verify(() => gamification.awardXp(5)).called(1);
+    });
+
+    test('emits OnboardingError when profile upsert fails', () async {
+      final authController = StreamController<AuthState>.broadcast();
+      final auth = MockAuthService();
+      when(() => auth.onAuthStateChange)
+          .thenAnswer((_) => authController.stream);
+      when(
+        () => auth.signInWithOAuth(any(), redirectTo: any(named: 'redirectTo')),
+      ).thenAnswer((_) async {});
+
+      final mockUser = MockUser();
+      when(() => auth.currentUser).thenReturn(mockUser);
+
+      final profileRepo = MockProfileRepository();
+      when(() => profileRepo.upsertProfile(any())).thenThrow(
+        Exception('DB error'),
+      );
+
+      final gamification = MockGamificationCubit();
+
+      final districtRepo = MockDistrictRepository();
+      when(() => districtRepo.lookupDistrict('46204'))
+          .thenAnswer((_) async => _lookupResult);
+
+      final cubit = OnboardingCubit(
+        districtRepository: districtRepo,
+        profileRepository: profileRepo,
+        gamificationCubit: gamification,
+        authService: auth,
+      );
+
+      final states = <OnboardingState>[];
+      final sub = cubit.stream.listen(states.add);
+
+      await cubit.submitZip('46204');
+      await cubit.submitAuth(OAuthProvider.google);
+
+      final fakeSession = _FakeSession();
+
+      // Profile upsert throws synchronously so the error state arrives quickly;
+      // still wait on the stream rather than a fixed delay.
+      final doneFuture = cubit.stream
+          .firstWhere((s) => s is OnboardingError)
+          .timeout(const Duration(seconds: 5));
+
+      authController.add(AuthState(AuthChangeEvent.signedIn, fakeSession));
+
+      await doneFuture;
+
+      await sub.cancel();
+      await cubit.close();
+      await authController.close();
+
+      expect(states.last, isA<OnboardingError>());
+      verifyNever(() => gamification.awardXp(any()));
+    });
+  });
+}
+
+// Minimal fake Session for constructing AuthState in tests.
+class _FakeSession extends Fake implements Session {}


### PR DESCRIPTION
## Summary

- Adds sealed `OnboardingState` hierarchy (`Initial → ZipLoading → ZipVerified → AuthPending → Complete / Error`) and `OnboardingCubit` with the full ZIP → OAuth → profile-save flow
- Adds `AuthService` abstraction over Supabase OAuth so the cubit can be tested without a real client
- Adds `OfficialResponse` Dart model and `DistrictRepository` wrapping the `lookup-district` Edge Function
- Fixes `ProfileRepository.upsertProfile` (`update` → `upsert`) and adds `GamificationCubit.awardXp` stub
- Adds 12 cubit unit tests covering ZIP validation, auth, and `completeOnboarding` happy/sad paths

Closes #4

## Test plan

- [x] `flutter test test/features/onboarding/onboarding_cubit_test.dart` — all 12 pass
- [x] `flutter analyze` — no issues
- [x] Manual: serve `lookup-district` locally (`supabase functions serve lookup-district --env-file .env.local`) and curl with an Indiana ZIP to verify end-to-end response shape matches `OfficialResponse`

## Notes

The `OnboardingScreen` UI and DI wiring (`MultiBlocProvider`) are intentionally left for the next issue — this PR is scoped to the state layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)